### PR TITLE
Clean up compiler warnings

### DIFF
--- a/hybconfig.cpp
+++ b/hybconfig.cpp
@@ -35,7 +35,7 @@ hybridization_configuration::hybridization_configuration(const alps::params &p):
 }
 
 void hybridization_configuration::dump() {
-    for (int i=0;i<hybmat_.size();i++)
+    for (std::size_t i=0;i<hybmat_.size();i++)
         std::cout << "Weight for orbital " << i << " : " << hybmat_[i].full_weight() << std::endl;
 }
 

--- a/hybevaluate.cpp
+++ b/hybevaluate.cpp
@@ -34,6 +34,7 @@
 void evaluate_basics(const alps::accumulators::result_set &results,
                      const alps::params &parms,
                      alps::hdf5::archive &solver_output){
+  (void)solver_output;
 
   std::size_t n_orbitals=parms["FLAVORS"];
   double beta=parms["BETA"];
@@ -52,19 +53,22 @@ void evaluate_basics(const alps::accumulators::result_set &results,
       sim_file << "orbital " << i << ": " << order << std::endl;
     }
     {
-      int tot_acc=0,cur_prec = sim_file.precision();
-      for (int i=0;i<nacc.size();i++) tot_acc += nacc[i];
+      int tot_acc=0;
+      std::streamsize cur_prec = sim_file.precision();
+      for (std::size_t i=0;i<nacc.size();i++) tot_acc += nacc[i];
       sim_file << std::endl << "|------------- Simulation details after " << nsweeps << " sweeps ------------|" << std::endl;
       sim_file << "  Total acceptance rate = " << std::setprecision(2) << std::fixed;
       sim_file << (((double)tot_acc)/nsweeps)*100 << "%" << std::endl;
       sim_file << "  Individual acceptance rate for update " << std::endl;
-      for (int i=0;i<nacc.size();i++) {
+      for (std::size_t i=0;i<nacc.size();i++) {
           sim_file << "     " << update_type[i] << " = ";
           sim_file << std::setprecision(2) << std::fixed << (((double)nacc[i])/nsweeps)*100 << "%";
           sim_file << " (proposal rate = ";
           sim_file << std::setprecision(2) << std::fixed << (((double)nprop[i])/nsweeps)*100 << "%)" << std::endl;
       }
       sim_file << "|-----------------------------------------------------------------|" << std::endl;
+      sim_file.unsetf(std::ios_base::fixed);
+      sim_file.precision(cur_prec);
     }
     sim_file.close();
     std::ofstream obs_file("observables.dat");//equal-time correlators
@@ -481,6 +485,7 @@ void evaluate_nnw(const alps::accumulators::result_set &results,
 void evaluate_sector_statistics(const alps::accumulators::result_set &results,
                                 const alps::params &parms,
                                 alps::hdf5::archive &solver_output){
+  (void)solver_output;
 
   if(!(parms["cthyb.MEASURE_sector_statistics"].as<bool>())) return;
 
@@ -664,4 +669,3 @@ alps::gf::omega_sigma_gf_with_tail translate_Gw_to_h5gf(matsubara_green_function
   Gw_h5gf.set_tail(1, tail);
   return Gw_h5gf;
 }
-

--- a/hyblocal.cpp
+++ b/hyblocal.cpp
@@ -665,6 +665,4 @@ void local_configuration::measure_sector_statistics(std::vector<double> &sector_
     }
     sector_statistics[state+full_line_states]+=(beta_-tau)/beta_*sign;//don't forget the last interval
   }
-  double sum=0;
 }
-

--- a/hybmatrix.cpp
+++ b/hybmatrix.cpp
@@ -78,6 +78,7 @@ double hybmatrix::hyb_weight_change_insert(const segment &new_segment, int orbit
 
 //actually insert an operator pair and change the configuration
 void hybmatrix::insert_segment(const segment &new_segment, int orbital){
+  (void)orbital;
   //std::cout<<clred<<"upon entering insert segment: "<<*this<<cblack<<std::endl;
   //consistency_check();
   //enlarge the M-matrix by one
@@ -113,6 +114,8 @@ void hybmatrix::insert_segment(const segment &new_segment, int orbital){
 }
 //compute the hybridization weight change when an operator pair is removed
 double hybmatrix::hyb_weight_change_remove(const segment &new_segment, int orbital, const hybfun &Delta){
+  (void)orbital;
+  (void)Delta;
   //std::cout<<clgreen<<"proposing to remove the segment: "<<new_segment<<cblack<<std::endl;
   int k1=cdagger_index_map_[new_segment.t_start_];
   int k2=c_index_map_[new_segment.t_end_];
@@ -132,6 +135,7 @@ double hybmatrix::hyb_weight_change_remove(const segment &new_segment, int orbit
 
 //actually remove an operator pair and change the configuration
 void hybmatrix::remove_segment(const segment &new_segment, int orbital){
+  (void)orbital;
   //std::cout<<clblue<<"upon entering remove segment: "<<*this<<cblack<<std::endl;
   //consistency_check();
   
@@ -355,5 +359,4 @@ void hybmatrix::measure_Gl(std::vector<double> &Gl, std::vector<double> &Fl , co
     }
   }
 }
-
 

--- a/hybmatrix_nfft.cpp
+++ b/hybmatrix_nfft.cpp
@@ -43,8 +43,6 @@ void hybmatrix::measure_Gw(std::vector<double> &Gwr, std::vector<double> &Gwi , 
   for (hyb_map_t::const_iterator it= cdagger_index_map_.begin(); it != cdagger_index_map_.end(); ++it) {
     cdagger_times[it->second] = it->first;
   }
-  clock_t t_nfft_start=clock();
-
   int size2=size()*size();
   int n_omega_meas=Gwr.size();
   //nfft calculation
@@ -58,7 +56,6 @@ void hybmatrix::measure_Gw(std::vector<double> &Gwr, std::vector<double> &Gwi , 
 
   // init a one dimensional plan
   {
-    std::size_t nfft_flags_first = PRE_PHI_HUT| PRE_PSI| MALLOC_X| MALLOC_F_HAT| MALLOC_F|FFTW_INIT| FFT_OUT_OF_PLACE;
     std::size_t nfft_flags_later = PRE_PHI_HUT| PRE_PSI| FFT_OUT_OF_PLACE;
     std::size_t fftw_flags= FFTW_MEASURE| FFTW_DESTROY_INPUT;
     static int n[1];
@@ -153,7 +150,6 @@ void hybmatrix::measure_G2w(std::vector<std::complex<double> > &G2w, std::vector
     cdagger_times[it->second] = it->first;
   }
 
-  int size2=size()*size();
   int n_omega_meas=N_w_aux;//this is the effective number of fermionic frequencies needed
 
   //nfft calculation

--- a/hybupdates.cpp
+++ b/hybupdates.cpp
@@ -73,13 +73,14 @@ void hybridization::update(){
   }//N_meas
 
   if(VERBOSE && sweeps%10000==0 && crank==0) {
-    int tot_acc=0,cur_prec = std::cout.precision();
-    for (int i=0;i<nacc.size();i++) tot_acc += nacc[i];
+    int tot_acc=0;
+    std::streamsize cur_prec = std::cout.precision();
+    for (std::size_t i=0;i<nacc.size();i++) tot_acc += nacc[i];
     std::cout << std::endl << "|------------- Simulation details after " << sweeps << " sweeps ------------|" << std::endl;
     std::cout << "  Total acceptance rate = " << std::setprecision(2) << std::fixed;
     std::cout << (((double)tot_acc)/sweeps)*100 << "%" << std::endl;
     std::cout << "  Individual acceptance rate for update " << std::endl;
-    for (int i=0;i<nacc.size();i++) {
+    for (std::size_t i=0;i<nacc.size();i++) {
       std::cout << "     " << update_type[i] << " = ";
       std::cout << std::setprecision(2) << std::fixed << (((double)nacc[i])/sweeps)*100 << "%";
       std::cout << " (proposal rate = ";
@@ -371,4 +372,3 @@ void hybridization::spin_flip_update(int orbital){
     hyb_config.insert_segment(new_segment, orbital);
   }
 }
-


### PR DESCRIPTION
## Summary
- remove unused locals in sector statistics and NFFT measurement code
- mark intentionally unused interface parameters explicitly
- use size_t for vector-size loop counters
- restore stream formatting state after writing acceptance statistics

## Verification
- git diff --check
- Clean warning build was verified with -Wall -Wextra -Wpedantic using ALPSCore at /Users/egull/Projects/ALPSCore/install_2/share/ALPSCore on top of the CMake fixes in PR #19.

Note: a fresh warning build directly from current master with install_2 is blocked by the existing CMake/Boost imported-target issue addressed separately in PR #19.