### PR TITLE
Fix Boost.Bind global placeholder deprecation warning

### DIFF
--- a/hybmain.cpp
+++ b/hybmain.cpp
@@ -30,7 +30,7 @@
 #include <ctime>
 #include "hyb.hpp"
 #include "hybevaluate.hpp"
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #ifdef ALPS_HAVE_MPI
 #include <alps/mc/mpiadapter.hpp>


### PR DESCRIPTION
## Summary

- Replace `#include <boost/bind.hpp>` with `#include <boost/bind/bind.hpp>` in `hybmain.cpp`
- `boost/bind.hpp` injects `_1`, `_2`, … into the global namespace, which Boost 1.73+ warns about at compile time
- No `using namespace boost::placeholders` needed since the only call site (`s.run(boost::bind(&stop_callback, ...))`) uses a plain function pointer with no placeholders

## Test plan

- [ ] Build with Boost ≥ 1.73 and confirm the `#pragma message` deprecation note no longer appears
- [ ] Verify `alps_cthyb` links and runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)